### PR TITLE
Fix: unknown revision or path not in the working tree.

### DIFF
--- a/git-copy/entrypoint.sh
+++ b/git-copy/entrypoint.sh
@@ -83,8 +83,16 @@ BASE_DIR=$(pwd)
 cd "$CLONE_DIR"
 
 echo "Creating new branch: ${INPUT_BRANCH}"
+git fetch --all --tags
 git checkout -b "$INPUT_BRANCH"
-git reset --hard "origin/$INPUT_BRANCH"  || true
+
+# Reset to remote branch if it exists
+if git show-ref --verify --quiet "refs/remotes/origin/$INPUT_BRANCH"; then
+  git reset --hard "origin/$INPUT_BRANCH"
+else
+  echo "Warning: origin/$INPUT_BRANCH not found, skipping reset."
+fi
+
 git rebase -Xours "${INPUT_PR_BASE}"
 
 DEST_COPY="$CLONE_DIR/$INPUT_DST"


### PR DESCRIPTION
This is an error we encountered. This PR, can probably help.
```
Creating new branch: update_api_client
+ BASE_DIR=/github/workspace
+ cd /tmp/tmp.dBfDKk
+ echo 'Creating new branch: update_api_client'
+ git checkout -b update_api_client
Switched to a new branch 'update_api_client'
+ git reset --hard origin/update_api_client
fatal: ambiguous argument 'origin/update_api_client': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
+ true
+ git rebase -Xours v2
fatal: invalid upstream 'v2'
```