### PR TITLE
fix: correct variable interpolation in GitHub API URLs

### DIFF
--- a/git-commit/entrypoint.sh
+++ b/git-commit/entrypoint.sh
@@ -134,7 +134,7 @@ if [ -z "$(git status -s)" ]; then
     --connect-timeout 10 \
     -u "${INPUT_USER_NAME}:${API_TOKEN_GITHUB}" \
     -H 'Content-Type: application/json' \
-    "https://api.github.com/repos/{$INPUT_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${INPUT_BRANCH}" > pull_request.json
+    "https://api.github.com/repos/${INPUT_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${INPUT_BRANCH}" > pull_request.json
 
   count=$(jq '. | length' pull_request.json)
   if [ "$count" -eq 1 ]
@@ -162,7 +162,7 @@ curl \
   -u "${INPUT_USER_NAME}:${API_TOKEN_GITHUB}" \
   -X POST -H 'Content-Type: application/json' \
   --data "{\"head\":\"$INPUT_BRANCH\",\"base\":\"${INPUT_PR_BASE}\", \"title\": \"${INPUT_PR_TITLE}\", \"body\": \"${PR_DESCRIPTION_ESCAPED}\"}" \
-  "https://api.github.com/repos/{$INPUT_REPOSITORY}/pulls" > pull_request.json
+  "https://api.github.com/repos/${INPUT_REPOSITORY}/pulls" > pull_request.json
 
 PR_EXISTS=$(jq '.errors' pull_request.json)
 if [ "$PR_EXISTS" = 'null' ]; then
@@ -178,7 +178,7 @@ curl \
   --connect-timeout 10 \
   -u "${INPUT_USER_NAME}:${API_TOKEN_GITHUB}" \
   -H 'Content-Type: application/json' \
-  "https://api.github.com/repos/{$INPUT_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${INPUT_BRANCH}" > pull_request.json
+  "https://api.github.com/repos/${INPUT_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${INPUT_BRANCH}" > pull_request.json
 
 PR_URL=$(jq -r '.[0].html_url' pull_request.json)
 update_labels $(jq -r '.[0].number' pull_request.json)

--- a/git-copy/entrypoint.sh
+++ b/git-copy/entrypoint.sh
@@ -133,7 +133,7 @@ if ! git status | grep -q "Changes to be committed"; then
     --connect-timeout 10 \
     -u "${INPUT_USER_NAME}:${API_TOKEN_GITHUB}" \
     -H 'Content-Type: application/json' \
-    "https://api.github.com/repos/{$INPUT_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${INPUT_BRANCH}" | tee pull_request.json
+    "https://api.github.com/repos/${INPUT_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${INPUT_BRANCH}" | tee pull_request.json
 
   count=$(jq '. | length' pull_request.json)
   if [ "$count" -eq 1 ]
@@ -160,7 +160,7 @@ curl \
   -u "${INPUT_USER_NAME}:${API_TOKEN_GITHUB}" \
   -X POST -H 'Content-Type: application/json' \
   --data "{\"head\":\"$INPUT_BRANCH\",\"base\":\"${INPUT_PR_BASE}\", \"title\": \"${INPUT_PR_TITLE}\", \"body\": \"${PR_DESCRIPTION_ESCAPED}\"}" \
-  "https://api.github.com/repos/{$INPUT_REPOSITORY}/pulls" | tee pull_request.json
+  "https://api.github.com/repos/${INPUT_REPOSITORY}/pulls" | tee pull_request.json
 
 PR_EXISTS=$(jq '.errors' pull_request.json)
 # PR does not exist


### PR DESCRIPTION
## Summary

- `{$INPUT_REPOSITORY}` → `${INPUT_REPOSITORY}` in all GitHub API URLs across both `git-commit` and `git-copy` actions
- The misplaced `{` produced URLs like `/repos/{owner/repo}/pulls` — GitHub returns an error object, and `jq '. | length'` fails with `Cannot index object with number`
- Affects the "nothing to commit" and PR creation/lookup paths in both actions

## Test plan

- [ ] Trigger a run that hits the "Nothing to commit" path → should no longer fail on jq
- [ ] Trigger a run that creates a PR → API call should succeed