### PR TITLE
fix(git-commit, git-copy): build API payloads with jq to escape JSON properly

### DIFF
--- a/git-commit/entrypoint.sh
+++ b/git-commit/entrypoint.sh
@@ -5,25 +5,14 @@ set -e
 update_labels () {
   PR_ID=$1
 
-  IFS=','
-  LABELS=""
-  # Loop over the input labels
-  for LABEL in $INPUT_PR_LABELS; do
-    if [ -z "$LABELS" ]; then
-      LABELS="\"$LABEL\""  # First label, no comma
-    else
-      LABELS="$LABELS, \"$LABEL\""  # Subsequent labels, add a comma
-    fi
-  done
-
-  if [ -n "$LABELS" ]; then
-    # Wrap the labels in square brackets and prepare the JSON payload
-    LABELS_JSON="{\"labels\":[$LABELS]}"
+  if [ -n "$INPUT_PR_LABELS" ]; then
+    LABELS_JSON=$(jq -cn --arg labels "$INPUT_PR_LABELS" \
+      '{labels: ($labels | split(",") | map(select(. != "")))}')
 
     curl \
       -L \
       --connect-timeout 10 \
-      -u "$INPUT_USER_NAME}:$API_TOKEN_GITHUB" \
+      -u "$INPUT_USER_NAME:$API_TOKEN_GITHUB" \
       -X POST \
       -H "Accept: application/vnd.github+json" \
       -d "$LABELS_JSON" \
@@ -155,13 +144,18 @@ git push -u origin --force HEAD:"$INPUT_BRANCH"
 # Exit early if pull request is not enabled.
 [ "$INPUT_PR_CREATE" != true ] && exit 0
 
-PR_DESCRIPTION_ESCAPED="${INPUT_PR_DESCRIPTION//$'\n'/\\n}"
+PR_PAYLOAD=$(jq -n \
+  --arg head "$INPUT_BRANCH" \
+  --arg base "$INPUT_PR_BASE" \
+  --arg title "$INPUT_PR_TITLE" \
+  --arg body "$INPUT_PR_DESCRIPTION" \
+  '{head: $head, base: $base, title: $title, body: $body}')
 
 curl \
   --connect-timeout 10 \
   -u "${INPUT_USER_NAME}:${API_TOKEN_GITHUB}" \
   -X POST -H 'Content-Type: application/json' \
-  --data "{\"head\":\"$INPUT_BRANCH\",\"base\":\"${INPUT_PR_BASE}\", \"title\": \"${INPUT_PR_TITLE}\", \"body\": \"${PR_DESCRIPTION_ESCAPED}\"}" \
+  --data "$PR_PAYLOAD" \
   "https://api.github.com/repos/${INPUT_REPOSITORY}/pulls" > pull_request.json
 
 PR_EXISTS=$(jq '.errors' pull_request.json)

--- a/git-copy/entrypoint.sh
+++ b/git-copy/entrypoint.sh
@@ -3,25 +3,14 @@
 update_labels () {
   PR_ID=$1
 
-  IFS=','
-  LABELS=""
-  # Loop over the input labels
-  for LABEL in $INPUT_PR_LABELS; do
-    if [ -z "$LABELS" ]; then
-      LABELS="\"$LABEL\""  # First label, no comma
-    else
-      LABELS="$LABELS, \"$LABEL\""  # Subsequent labels, add a comma
-    fi
-  done
-
-  if [ -n "$LABELS" ]; then
-    # Wrap the labels in square brackets and prepare the JSON payload
-    LABELS_JSON="{\"labels\":[$LABELS]}"
+  if [ -n "$INPUT_PR_LABELS" ]; then
+    LABELS_JSON=$(jq -cn --arg labels "$INPUT_PR_LABELS" \
+      '{labels: ($labels | split(",") | map(select(. != "")))}')
 
     curl \
       -L \
       --connect-timeout 10 \
-      -u "$INPUT_USER_NAME}:$API_TOKEN_GITHUB" \
+      -u "$INPUT_USER_NAME:$API_TOKEN_GITHUB" \
       -X POST \
       -H "Accept: application/vnd.github+json" \
       -d "$LABELS_JSON" \
@@ -153,13 +142,18 @@ git push -u origin --force HEAD:"$INPUT_BRANCH"
 # Exit early if pull request creation is not needed
 [ "$INPUT_PR_CREATE" != true ] && exit 0
 
-PR_DESCRIPTION_ESCAPED="${INPUT_PR_DESCRIPTION//$'\n'/\\n}"
+PR_PAYLOAD=$(jq -n \
+  --arg head "$INPUT_BRANCH" \
+  --arg base "$INPUT_PR_BASE" \
+  --arg title "$INPUT_PR_TITLE" \
+  --arg body "$INPUT_PR_DESCRIPTION" \
+  '{head: $head, base: $base, title: $title, body: $body}')
 
 curl \
   --connect-timeout 10 \
   -u "${INPUT_USER_NAME}:${API_TOKEN_GITHUB}" \
   -X POST -H 'Content-Type: application/json' \
-  --data "{\"head\":\"$INPUT_BRANCH\",\"base\":\"${INPUT_PR_BASE}\", \"title\": \"${INPUT_PR_TITLE}\", \"body\": \"${PR_DESCRIPTION_ESCAPED}\"}" \
+  --data "$PR_PAYLOAD" \
   "https://api.github.com/repos/${INPUT_REPOSITORY}/pulls" | tee pull_request.json
 
 PR_EXISTS=$(jq '.errors' pull_request.json)


### PR DESCRIPTION
## Problem

Both `git-commit` and `git-copy` build the pull-request creation payload by string interpolation and only escape newlines:

```sh
PR_DESCRIPTION_ESCAPED="${INPUT_PR_DESCRIPTION//$'\n'/\\n}"
--data "{\"head\":\"$INPUT_BRANCH\", ... \"body\": \"${PR_DESCRIPTION_ESCAPED}\"}"
```

Any double quote, backslash, or carriage return in `pr_title` / `pr_description` produces invalid JSON, the API returns 400/422, and PR creation fails. GitHub release notes use CRLF line endings, so passing a release body as `pr_description` always breaks (reproduced with the real `webrpc/gen-golang v0.32.5` notes: `jq: parse error: control characters from U+0000 through U+001F must be escaped`).

## Fix (applied identically to both actions)

- Build the PR creation payload with `jq -n --arg` — correct escaping for all inputs, including the title.
- Build the `update_labels` payload with `jq` instead of manual string concatenation. This also removes the `IFS=','` assignment that leaked out of the function.
- Fix a stray `}` in the `update_labels` curl credentials: `-u "$INPUT_USER_NAME}:$API_TOKEN_GITHUB"`.

Also drops the `${var//...}` bash-ism from `#!/bin/sh` scripts.

## Testing

- `shellcheck -s sh` and `sh -n` pass on both scripts (remaining warnings are pre-existing).
- Payload round-trip tested with hostile input (`"quotes"`, `back\slash`, CRLF): output is valid JSON and decodes byte-identical.

Motivation: webrpc/webrpc wants to include generator release notes in automated bump PR descriptions, which is impossible with the current escaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)